### PR TITLE
Improve Discord speech quality and vision syncing

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -88,7 +88,8 @@ async def send_audio(data: bytes, user_name: str,
                      image_b64: str | None = None) -> None:
     def _post():
         try:
-            files = {"file": ("audio.mp3", data, "audio/mpeg")}
+            # Use uncompressed PCM audio for better speech recognition quality
+            files = {"file": ("audio.wav", data, "audio/wav")}
             form = {
                 "channel_id": str(DISCORD_TEXT_CHANNEL),
                 "user_name": user_name,
@@ -129,7 +130,8 @@ async def voice_listener(vc: discord.VoiceClient) -> None:
     CHUNK_SEC = float(os.getenv("VOICE_CHUNK_SEC", "1.2"))
 
     while vc.is_connected():
-        sink = discord.sinks.MP3Sink()
+        # Record raw PCM data (WAV) instead of MP3 to avoid extra compression artifacts
+        sink = discord.sinks.WaveSink()
         done = asyncio.Event()
 
         async def _callback(s, *_):

--- a/static/app.js
+++ b/static/app.js
@@ -62,6 +62,7 @@ function App() {
   const grabberCanvasRef = React.useRef(null);
   const grabberTimerRef = React.useRef(null);
   const grabberStreamRef = React.useRef(null);
+  const lastVisionSentRef = React.useRef(0);
 
   const [imagePolicy, setImagePolicy] = React.useState('auto'); // 'auto' | 'always' | 'never'
   const [latestFrameUrl, setLatestFrameUrl] = React.useState(null);
@@ -566,6 +567,18 @@ function captureLatestFrame() {
   if (now - (previewTickRef.current || 0) > 500) {
     setLatestFrameUrl(latestFrameRef.current);
     previewTickRef.current = now;
+  }
+
+  // Periodically push the latest frame to the backend so Discord users get vision
+  const nowMs = Date.now();
+  if (textChannelId && nowMs - lastVisionSentRef.current > 5000) {
+    lastVisionSentRef.current = nowMs;
+    const payload = { image: latestFrameRef.current, channel_id: textChannelId };
+    fetch('/vision/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary
- Switch Discord recording to WAV for clearer speech recognition
- Periodically send captured screen frames to backend so Discord interactions include vision
- Allow backend vision endpoint to resolve guild from channel ID

## Testing
- `python -m py_compile discord_bot.py web_interface.py ai.py`

------
https://chatgpt.com/codex/tasks/task_e_6898a3a3809c832dae01a825f46b92dc